### PR TITLE
User Agent `id` field should not change when using new credential

### DIFF
--- a/couchbase-analytics-java-client/src/main/java/com/couchbase/analytics/client/java/Cluster.java
+++ b/couchbase-analytics-java-client/src/main/java/com/couchbase/analytics/client/java/Cluster.java
@@ -19,6 +19,8 @@ package com.couchbase.analytics.client.java;
 import com.couchbase.analytics.client.java.internal.Certificates;
 import com.couchbase.analytics.client.java.internal.RawQueryMetadata;
 import com.couchbase.analytics.client.java.internal.utils.BuilderPropertySetter;
+import com.couchbase.analytics.client.java.internal.utils.UserAgentBuilder;
+import com.couchbase.analytics.client.java.internal.utils.VersionAndGitHash;
 import okhttp3.HttpUrl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.UUID;
 import java.util.function.Consumer;
 
 import static com.couchbase.analytics.client.java.internal.utils.lang.CbCollections.listOf;
@@ -46,6 +49,16 @@ public class Cluster implements Queryable, Closeable {
   private final String connectionString;
   private final ClusterOptions.Unmodifiable options;
   private final HttpUrl url;
+
+  private final String userAgent = new UserAgentBuilder()
+    .append(
+      "java-analytics",
+      VersionAndGitHash.from(Cluster.class).version(),
+      "id=" + UUID.randomUUID()
+    )
+    .appendJava()
+    .appendOs()
+    .build();
 
   private static HttpUrl parseAnalyticsUrl(String s) {
     HttpUrl url = HttpUrl.get(s);
@@ -83,7 +96,7 @@ public class Cluster implements Queryable, Closeable {
     warnIfConfigurationIsInsecure(url, options);
   }
 
-  private static QueryExecutor newQueryExecutor(
+  private QueryExecutor newQueryExecutor(
     ClusterOptions.Unmodifiable options,
     HttpUrl url,
     Credential credential
@@ -95,7 +108,8 @@ public class Cluster implements Queryable, Closeable {
         credential
       ),
       url,
-      options
+      options,
+      userAgent
     );
   }
 

--- a/couchbase-analytics-java-client/src/main/java/com/couchbase/analytics/client/java/QueryExecutor.java
+++ b/couchbase-analytics-java-client/src/main/java/com/couchbase/analytics/client/java/QueryExecutor.java
@@ -18,8 +18,6 @@ package com.couchbase.analytics.client.java;
 
 import com.couchbase.analytics.client.java.codec.Deserializer;
 import com.couchbase.analytics.client.java.internal.RawQueryMetadata;
-import com.couchbase.analytics.client.java.internal.utils.UserAgentBuilder;
-import com.couchbase.analytics.client.java.internal.utils.VersionAndGitHash;
 import com.couchbase.analytics.client.java.internal.utils.json.Mapper;
 import com.couchbase.analytics.client.java.internal.utils.time.Deadline;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -47,7 +45,6 @@ import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.function.Consumer;
 
@@ -66,18 +63,7 @@ class QueryExecutor {
     Duration.ofMinutes(1)
   );
 
-  private final VersionAndGitHash versionAndGitHash = VersionAndGitHash.from(getClass());
-
-  private final String userAgent = new UserAgentBuilder()
-    .append(
-      "java-analytics",
-      versionAndGitHash.version(),
-      "id=" + UUID.randomUUID()
-    )
-    .appendJava()
-    .appendOs()
-    .build();
-
+  private final String userAgent;
   private final AnalyticsOkHttpClient httpClient;
   final HttpUrl url;
   private final Deserializer defaultDeserializer;
@@ -87,7 +73,8 @@ class QueryExecutor {
   public QueryExecutor(
     AnalyticsOkHttpClient httpClient,
     HttpUrl url,
-    ClusterOptions.Unmodifiable clusterOptions
+    ClusterOptions.Unmodifiable clusterOptions,
+    String userAgent
   ) {
     this.httpClient = requireNonNull(httpClient);
     this.url = requireNonNull(url);
@@ -95,6 +82,7 @@ class QueryExecutor {
 
     this.defaultDeserializer = requireNonNull(clusterOptions.deserializer());
     this.maybeCouchbaseInternalNonProd = url.host().endsWith(".nonprod-project-avengers.com");
+    this.userAgent = requireNonNull(userAgent);
   }
 
   public QueryResult executeQuery(@Nullable QueryContext queryContext, String statement, Consumer<QueryOptions> options) {


### PR DESCRIPTION
Make Cluster responsible for generating the User Agent instead of QueryExecutor. This way, the `id` field of the user agent doesn't change every time `Cluster.credential()` creates a new QueryExecutor.
