### PR TITLE
Upgrade Jackson to 2.21.2

### DIFF
--- a/couchbase-analytics-java-client/fit/src/main/java/com/couchbase/analytics/fit/performer/util/CustomDeserializer.java
+++ b/couchbase-analytics-java-client/fit/src/main/java/com/couchbase/analytics/fit/performer/util/CustomDeserializer.java
@@ -1,9 +1,26 @@
+/*
+ * Copyright 2023 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.couchbase.analytics.fit.performer.util;
 
 import com.couchbase.analytics.client.java.codec.Deserializer;
 import com.couchbase.analytics.client.java.codec.TypeRef;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.jspecify.annotations.NullMarked;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -12,6 +29,8 @@ import java.lang.reflect.Type;
  * A custom deserializer for FIT that sneakily adds a field to the result
  * so the driver can verify the SDK honored the request to use a custom deserializer.
  */
+@NullMarked
+@SuppressWarnings("unchecked")
 public class CustomDeserializer implements Deserializer {
   private static final JsonMapper mapper = JsonMapper.builder().build();
 

--- a/couchbase-analytics-java-client/src/main/java/com/couchbase/analytics/client/java/QueryOptions.java
+++ b/couchbase-analytics-java-client/src/main/java/com/couchbase/analytics/client/java/QueryOptions.java
@@ -205,7 +205,7 @@ public final class QueryOptions {
           JsonObject.from(namedParameters);
 
           namedParameters.forEach((key, value) -> {
-            JsonNode jsonValue = toRepackagedJacksonNode(InternalJacksonSerDes.INSTANCE, value);
+            JsonNode jsonValue = toJacksonNode(InternalJacksonSerDes.INSTANCE, value);
             if (key.charAt(0) != '$') {
               query.set('$' + key, jsonValue);
             } else {
@@ -226,7 +226,7 @@ public final class QueryOptions {
         JsonObject.from(raw);
 
         raw.forEach((key, value) -> {
-          JsonNode jsonValue = toRepackagedJacksonNode(InternalJacksonSerDes.INSTANCE, value);
+          JsonNode jsonValue = toJacksonNode(InternalJacksonSerDes.INSTANCE, value);
           query.set(key, jsonValue);
         });
       }
@@ -255,7 +255,7 @@ public final class QueryOptions {
      * This allows the user to specify query parameters as POJOs
      * and have them serialized using their chosen serializer.
      */
-    private static JsonNode toRepackagedJacksonNode(
+    private static JsonNode toJacksonNode(
       JsonSerializer serializer,
       Object value
     ) {

--- a/couchbase-analytics-java-client/src/main/java/com/couchbase/analytics/client/java/internal/InternalJacksonSerDes.java
+++ b/couchbase-analytics-java-client/src/main/java/com/couchbase/analytics/client/java/internal/InternalJacksonSerDes.java
@@ -28,10 +28,6 @@ import java.io.IOException;
 /**
  * For internal SDK use only.
  *
- * @implNote The serializer is backed by a repackaged version of Jackson,
- * but this is an implementation detail users should not depend on.
- * <p>
- * Be aware that this serializer does not recognize standard Jackson annotations.
  * @see JacksonDeserializer
  */
 public class InternalJacksonSerDes implements JsonSerializer, Deserializer {

--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.20.1</version>
+                <version>2.21.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Upgrade Jackson and do some related gardening:

* Remove inaccurate comments about using a repackaged version of Jackson (we don't).
* Add a missing copyright header from way back in 2023.
* Add `@NullMarked` and `@SuppressWarnings` annotations to clean up a few warnings.