### PR TITLE
Upgrade OkHttp from 4.12.0 to 5.3.2

### DIFF
--- a/couchbase-analytics-java-client/pom.xml
+++ b/couchbase-analytics-java-client/pom.xml
@@ -115,33 +115,11 @@
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jetbrains.kotlin</groupId>
-                    <artifactId>kotlin-stdlib-jdk8</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jetbrains.kotlin</groupId>
-                    <artifactId>kotlin-stdlib-common</artifactId>
-                </exclusion>
-            </exclusions>
+            <artifactId>okhttp-jvm</artifactId>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp-tls</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jetbrains.kotlin</groupId>
-                    <artifactId>kotlin-stdlib-jdk8</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <!--suppress KotlinMavenPluginPhase: Not compiling Kotlin; just upgrading stdlib version -->
-            <artifactId>kotlin-stdlib</artifactId>
-            <version>2.1.21</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okio</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -314,14 +314,14 @@
             <dependency>
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>okhttp-bom</artifactId>
-                <version>4.12.0</version>
+                <version>5.3.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>com.squareup.okio</groupId>
                 <artifactId>okio</artifactId>
-                <version>3.12.0</version>
+                <version>3.17.0</version>
             </dependency>
             <dependency>
                 <groupId>org.junit</groupId>


### PR DESCRIPTION
and Okio from 3.12.0 to 3.17.0.

Remove exclusions for `kotlin-stdlib-*` because OkHttp 5 brings in only the modern unified `kotlin-stdlib` artifact.
