### PR TITLE
Add JWT auth and SetCredential RPC dispatch

### DIFF
--- a/couchbase-analytics-java-client/fit/src/main/java/com/couchbase/analytics/fit/performer/cluster/AnalyticsClusterConnection.java
+++ b/couchbase-analytics-java-client/fit/src/main/java/com/couchbase/analytics/fit/performer/cluster/AnalyticsClusterConnection.java
@@ -37,68 +37,76 @@ public class AnalyticsClusterConnection {
     this.request = request;
     this.onClusterConnectionClose = onClusterConnectionClose;
 
-    if (!request.hasOptions()) {
-      this.cluster = Cluster.newInstance(
-        request.getConnectionString(),
-        Credential.of(
-          request.getCredential().getUsernameAndPassword().getUsername(),
-          request.getCredential().getUsernameAndPassword().getPassword()
-        )
-      );
-    } else {
-      var options = request.getOptions();
+    this.cluster = Cluster.newInstance(
+      request.getConnectionString(),
+      credentialFromProto(request.getCredential()),
+      env -> {
+        if (!request.hasOptions()) {
+          return;
+        }
+        var options = request.getOptions();
 
-      if (options.hasDeserializer()) {
-        // Ignore. FIT driver can't specify alternate deserializers in a meaningful way.
-      }
+        if (options.hasDeserializer()) {
+          // Ignore. FIT driver can't specify alternate deserializers in a meaningful way.
+        }
 
-      this.cluster = Cluster.newInstance(
-        request.getConnectionString(),
-        Credential.of(
-          request.getCredential().getUsernameAndPassword().getUsername(),
-          request.getCredential().getUsernameAndPassword().getPassword()
-        ),
-        env -> {
-          env.timeout(timeout -> {
-            if (options.hasTimeout()) {
-              var timeoutOptions = options.getTimeout();
-              if (timeoutOptions.hasConnectTimeout()) {
-                timeout.connectTimeout(Duration.ofSeconds(timeoutOptions.getConnectTimeout().getSeconds()));
-              }
-              if (timeoutOptions.hasDispatchTimeout()) {
-                // todo - check with David if intentional
-                throw new UnsupportedOperationException("dispatchTimeout not exposed in SDK");
-              }
-              if (timeoutOptions.hasQueryTimeout()) {
-                timeout.queryTimeout(Duration.ofSeconds(timeoutOptions.getQueryTimeout().getSeconds()));
-              }
+        env.timeout(timeout -> {
+          if (options.hasTimeout()) {
+            var timeoutOptions = options.getTimeout();
+            if (timeoutOptions.hasConnectTimeout()) {
+              timeout.connectTimeout(Duration.ofSeconds(timeoutOptions.getConnectTimeout().getSeconds()));
             }
-          })
-          .security(sec -> {
-            if (options.hasSecurity()) {
-              var secOptions = options.getSecurity();
-              if (secOptions.hasTrustOnlyCapella()) {
-                sec.trustOnlyCapella();
-              }
-              if (secOptions.hasTrustOnlyPemString()) {
-                sec.trustOnlyPemString(secOptions.getTrustOnlyPemString());
-              }
-              if (secOptions.hasTrustOnlyPlatform()) {
-                sec.trustOnlyJvm();
-              }
-              if (secOptions.hasDisableServerCertificateVerification()) {
-                sec.disableServerCertificateVerification(secOptions.getDisableServerCertificateVerification());
-              }
-              if (secOptions.getCipherSuitesCount() > 0) {
-                sec.cipherSuites(secOptions.getCipherSuitesList());
-              }
+            if (timeoutOptions.hasDispatchTimeout()) {
+              // todo - check with David if intentional
+              throw new UnsupportedOperationException("dispatchTimeout not exposed in SDK");
             }
-          });
-          if (options.hasMaxRetries()) {
-            env.maxRetries(options.getMaxRetries());
+            if (timeoutOptions.hasQueryTimeout()) {
+              timeout.queryTimeout(Duration.ofSeconds(timeoutOptions.getQueryTimeout().getSeconds()));
+            }
+          }
+        })
+        .security(sec -> {
+          if (options.hasSecurity()) {
+            var secOptions = options.getSecurity();
+            if (secOptions.hasTrustOnlyCapella()) {
+              sec.trustOnlyCapella();
+            }
+            if (secOptions.hasTrustOnlyPemString()) {
+              sec.trustOnlyPemString(secOptions.getTrustOnlyPemString());
+            }
+            if (secOptions.hasTrustOnlyPlatform()) {
+              sec.trustOnlyJvm();
+            }
+            if (secOptions.hasDisableServerCertificateVerification()) {
+              sec.disableServerCertificateVerification(secOptions.getDisableServerCertificateVerification());
+            }
+            if (secOptions.getCipherSuitesCount() > 0) {
+              sec.cipherSuites(secOptions.getCipherSuitesList());
+            }
           }
         });
-    }
+        if (options.hasMaxRetries()) {
+          env.maxRetries(options.getMaxRetries());
+        }
+      });
+  }
+
+  /**
+   * Converts a protobuf Credential message to the SDK's Credential type.
+   * Switch is exhaustive on the oneof type case; adding a new variant to the
+   * proto will fail to compile here, which is the point.
+   * <p>
+   * FIT-internal: {@code public} only because {@link com.couchbase.analytics.fit.performer.rpc.JavaAnalyticsService} lives in a sibling package.
+   */
+  public static Credential credentialFromProto(fit.columnar.ClusterNewInstanceRequest.Credential proto) {
+    return switch (proto.getTypeCase()) {
+      case USERNAME_AND_PASSWORD -> Credential.of(
+        proto.getUsernameAndPassword().getUsername(),
+        proto.getUsernameAndPassword().getPassword()
+      );
+      case JWT_AUTH -> Credential.ofJwt(proto.getJwtAuth().getJwt());
+      case TYPE_NOT_SET -> throw new IllegalArgumentException("FIT request did not specify a credential.");
+    };
   }
 
   public Cluster cluster() {

--- a/couchbase-analytics-java-client/fit/src/main/java/com/couchbase/analytics/fit/performer/rpc/JavaAnalyticsService.java
+++ b/couchbase-analytics-java-client/fit/src/main/java/com/couchbase/analytics/fit/performer/rpc/JavaAnalyticsService.java
@@ -29,6 +29,7 @@ import fit.columnar.ClusterNewInstanceRequest;
 import fit.columnar.ColumnarServiceGrpc;
 import fit.columnar.EmptyResultOrFailureResponse;
 import fit.columnar.SdkConnectionError;
+import fit.columnar.SetCredentialRequest;
 import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -127,7 +128,13 @@ public class JavaAnalyticsService extends ColumnarServiceGrpc.ColumnarServiceImp
 
       var clusters = context.clusters();
       LOGGER.info("Dumping {} cluster connections for resource leak troubleshooting:", clusters.size());
-      clusters.forEach((key, value) -> LOGGER.info("Cluster connection {} {}", key, value.request().getCredential().getUsernameAndPassword().getUsername()));
+      clusters.forEach((key, value) -> {
+        var cred = value.request().getCredential();
+        var credDesc = cred.hasUsernameAndPassword()
+          ? cred.getUsernameAndPassword().getUsername()
+          : cred.getTypeCase().name();
+        LOGGER.info("Cluster connection {} {}", key, credDesc);
+      });
 
       responseObserver.onNext(ResultUtil.success(startTime));
     } catch (RuntimeException err) {
@@ -153,6 +160,23 @@ public class JavaAnalyticsService extends ColumnarServiceGrpc.ColumnarServiceImp
     var startTime = startTiming();
     try {
       context.closeAndRemoveAllClusters();
+      responseObserver.onNext(ResultUtil.success(startTime));
+    } catch (RuntimeException err) {
+      responseObserver.onNext(ResultUtil.failure(err, startTime));
+    }
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void setCredential(SetCredentialRequest request, StreamObserver<EmptyResultOrFailureResponse> responseObserver) {
+    var startTime = startTiming();
+    try {
+      var clusterId = request.getExecutionContext().getClusterId();
+      var cc = context.cluster(clusterId);
+      if (cc == null) {
+        throw new IllegalArgumentException("No cluster connection with id: " + clusterId);
+      }
+      cc.cluster().credential(AnalyticsClusterConnection.credentialFromProto(request.getCredential()));
       responseObserver.onNext(ResultUtil.success(startTime));
     } catch (RuntimeException err) {
       responseObserver.onNext(ResultUtil.failure(err, startTime));

--- a/fit-performer-protocol/fit-protocol/columnar/columnar.cluster_management.proto
+++ b/fit-performer-protocol/fit-protocol/columnar/columnar.cluster_management.proto
@@ -41,8 +41,15 @@ message ClusterNewInstanceRequest {
       string password = 2;
     }
 
+    // Authenticates using a JSON Web Token (JWT).
+    // The SDK sets an "Authorization: Bearer <jwt>" header on every HTTP request.
+    message JwtAuth {
+      string jwt = 1;
+    }
+
     oneof type {
       UsernameAndPassword username_and_password = 1;
+      JwtAuth jwt_auth = 2;
     }
   }
 
@@ -80,4 +87,12 @@ message ClusterCloseRequest {
 // The performer should close all Columnar Cluster objects it has open.  In the RFC this is `cluster.close()`.
 message CloseAllColumnarClustersRequest {
   ExecutionContext execution_context = 1;
+}
+
+// Requests the performer to update the credential on an existing cluster connection.
+// Per the EA RFC, `cluster.credential(newCredential)` replaces the credential used for subsequent requests.
+// The new credential must be the same type as the old one (e.g. JWT -> JWT).
+message SetCredentialRequest {
+  ExecutionContextClusterLevel execution_context = 1;
+  ClusterNewInstanceRequest.Credential credential = 2;
 }

--- a/fit-performer-protocol/fit-protocol/columnar/columnar.services.proto
+++ b/fit-performer-protocol/fit-protocol/columnar/columnar.services.proto
@@ -24,6 +24,10 @@ service ColumnarService {
   rpc ClusterNewInstance (ClusterNewInstanceRequest) returns (EmptyResultOrFailureResponse);
   rpc ClusterClose (ClusterCloseRequest) returns (EmptyResultOrFailureResponse);
   rpc CloseAllClusters (CloseAllColumnarClustersRequest) returns (EmptyResultOrFailureResponse);
+
+  // Updates the credential on a previously-created cluster connection.
+  // Maps to the EA RFC's `cluster.credential(newCredential)`.
+  rpc SetCredential (SetCredentialRequest) returns (EmptyResultOrFailureResponse);
 }
 
 // To better permit DRY, instance.executeQuery() and scope.executeQuery() are here rather than in their respective services.


### PR DESCRIPTION
Adds the JwtAuth proto variant and the SetCredential RPC so the test driver can rotate JWTs through cluster.credential(). Cluster construction now goes through a single credentialFromProto dispatch.