### PR TITLE
FIT: Include fractional seconds when converting durations

### DIFF
--- a/couchbase-analytics-java-client/fit/src/main/java/com/couchbase/analytics/fit/performer/cluster/AnalyticsClusterConnection.java
+++ b/couchbase-analytics-java-client/fit/src/main/java/com/couchbase/analytics/fit/performer/cluster/AnalyticsClusterConnection.java
@@ -19,8 +19,8 @@ package com.couchbase.analytics.fit.performer.cluster;
 
 import com.couchbase.analytics.client.java.Cluster;
 import com.couchbase.analytics.client.java.Credential;
+import com.couchbase.analytics.fit.performer.util.Durations;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -54,14 +54,14 @@ public class AnalyticsClusterConnection {
           if (options.hasTimeout()) {
             var timeoutOptions = options.getTimeout();
             if (timeoutOptions.hasConnectTimeout()) {
-              timeout.connectTimeout(Duration.ofSeconds(timeoutOptions.getConnectTimeout().getSeconds()));
+              timeout.connectTimeout(Durations.toJava(timeoutOptions.getConnectTimeout()));
             }
             if (timeoutOptions.hasDispatchTimeout()) {
               // todo - check with David if intentional
               throw new UnsupportedOperationException("dispatchTimeout not exposed in SDK");
             }
             if (timeoutOptions.hasQueryTimeout()) {
-              timeout.queryTimeout(Duration.ofSeconds(timeoutOptions.getQueryTimeout().getSeconds()));
+              timeout.queryTimeout(Durations.toJava(timeoutOptions.getQueryTimeout()));
             }
           }
         })

--- a/couchbase-analytics-java-client/fit/src/main/java/com/couchbase/analytics/fit/performer/query/QueryOptionsUtil.java
+++ b/couchbase-analytics-java-client/fit/src/main/java/com/couchbase/analytics/fit/performer/query/QueryOptionsUtil.java
@@ -19,10 +19,10 @@ package com.couchbase.analytics.fit.performer.query;
 import com.couchbase.analytics.client.java.QueryOptions;
 import com.couchbase.analytics.client.java.ScanConsistency;
 import com.couchbase.analytics.fit.performer.util.CustomDeserializer;
+import com.couchbase.analytics.fit.performer.util.Durations;
 import com.couchbase.analytics.fit.performer.util.grpc.ProtobufConversions;
 import org.jspecify.annotations.Nullable;
 
-import java.time.Duration;
 import java.util.function.Consumer;
 
 import static com.couchbase.analytics.fit.performer.util.grpc.ProtobufConversions.protobufStructToMap;
@@ -58,7 +58,7 @@ public class QueryOptionsUtil {
         options.raw(protobufStructToMap(opts.getRaw()));
       }
       if (opts.hasTimeout()) {
-        options.timeout(Duration.ofSeconds(opts.getTimeout().getSeconds()));
+        options.timeout(Durations.toJava(opts.getTimeout()));
       }
       if (opts.hasDeserializer() && opts.getDeserializer().hasCustom()) {
         CustomDeserializer customDeserializer = new CustomDeserializer();

--- a/couchbase-analytics-java-client/fit/src/main/java/com/couchbase/analytics/fit/performer/query/QueryResultPushBasedStreamer.java
+++ b/couchbase-analytics-java-client/fit/src/main/java/com/couchbase/analytics/fit/performer/query/QueryResultPushBasedStreamer.java
@@ -21,6 +21,7 @@ import com.couchbase.analytics.client.java.QueryOptions;
 import com.couchbase.analytics.client.java.Queryable;
 import com.couchbase.analytics.client.java.Row;
 import com.couchbase.analytics.fit.performer.content.ContentAsUtil;
+import com.couchbase.analytics.fit.performer.util.Durations;
 import com.couchbase.analytics.fit.performer.util.ErrorUtil;
 import fit.columnar.EmptyResultOrFailureResponse;
 import fit.columnar.ExecuteQueryRequest;
@@ -122,8 +123,8 @@ class PushBasedStreamer extends Thread {
     var metrics = sdk.metrics();
     return fit.columnar.QueryResultMetadataResponse.QueryMetadata.newBuilder()
       .setMetrics(fit.columnar.QueryResultMetadataResponse.QueryMetadata.Metrics.newBuilder()
-        .setElapsedTime(com.google.protobuf.Duration.newBuilder().setSeconds(metrics.elapsedTime().getSeconds()))
-        .setExecutionTime(com.google.protobuf.Duration.newBuilder().setSeconds(metrics.executionTime().getSeconds()))
+        .setElapsedTime(Durations.toFit(metrics.elapsedTime()))
+        .setExecutionTime(Durations.toFit(metrics.executionTime()))
         .setResultCount(metrics.resultCount())
         .setResultSize(metrics.resultSize())
         .setProcessedObjects(metrics.processedObjects())

--- a/couchbase-analytics-java-client/fit/src/main/java/com/couchbase/analytics/fit/performer/util/Durations.java
+++ b/couchbase-analytics-java-client/fit/src/main/java/com/couchbase/analytics/fit/performer/util/Durations.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.analytics.fit.performer.util;
+
+public class Durations {
+  private Durations() {
+  }
+
+  public static com.google.protobuf.Duration toFit(java.time.Duration d) {
+    return com.google.protobuf.Duration.newBuilder()
+      .setSeconds(d.getSeconds())
+      .setNanos(d.getNano())
+      .build();
+  }
+
+  public static java.time.Duration toJava(com.google.protobuf.Duration d) {
+    return java.time.Duration.ofSeconds(d.getSeconds(), d.getNanos());
+  }
+}


### PR DESCRIPTION
Add a new `Durations` utility class with methods to convert between Protobuf and Java durations. When converting, also transfer the nanosecond component.