### PR TITLE
Depend on `okio-jvm` instead of `okio`

### DIFF
--- a/couchbase-analytics-java-client/pom.xml
+++ b/couchbase-analytics-java-client/pom.xml
@@ -123,7 +123,7 @@
         </dependency>
         <dependency>
             <groupId>com.squareup.okio</groupId>
-            <artifactId>okio</artifactId>
+            <artifactId>okio-jvm</artifactId>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,7 @@
             </dependency>
             <dependency>
                 <groupId>com.squareup.okio</groupId>
-                <artifactId>okio</artifactId>
+                <artifactId>okio-jvm</artifactId>
                 <version>3.17.0</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Because Maven doesn't know how to read the
module metadata :-/